### PR TITLE
Refactor & new error model

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,9 @@
+function ValidationError (errors) {
+    this.data = errors;
+    this.message = 'ValidationError';
+}
+
+ValidationError.prototype = Object.create(Error.prototype);
+ValidationError.prototype.constructor = ValidationError;
+
+export default ValidationError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,12 @@ const defaultConfig = {
     validateOnSave: false,
 };
 
-function doValidation (validator, fnName, value, args) {
+function doValidation (validator, fnName, value, options) {
     // The argument can be a boolean for argumentless validation, or an
     // array of options passed to the validator
     return typeof args === 'boolean' ?
         validator[fnName](value) === args
-        : validator[fnName](value, args.join());
+        : validator[fnName](value, options);
 }
 
 export default function validationPlugin (bookshelf, config = defaultConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,18 @@ const defaultConfig = {
     validateOnSave: false,
 };
 
-function doValidation (validator, fnName, value, options) {
-    // The argument can be a boolean for argumentless validation, or an
-    // array of options passed to the validator
-    return typeof options === 'boolean' ?
-        validator[fnName](value) === options
-        : validator[fnName](value, options);
+function doValidation (validator, fnName, value, args) {
+    // The argument can be a boolean for argumentless validation,
+    // a single argument or object, or an array of argument values
+    if (typeof args === 'boolean') {
+        return validator[fnName](value) === args;
+    }
+
+    if (!Array.isArray(args)) {
+        return validator[fnName](value, args);
+    }
+
+    return validator[fnName](value, ...args);
 }
 
 export default function validationPlugin (bookshelf, config = defaultConfig) {
@@ -38,7 +44,7 @@ export default function validationPlugin (bookshelf, config = defaultConfig) {
                 for (const validation of validations) {
                     const {
                         method: fnName,
-                        options = true,
+                        args = true,
                         error,
                     } = validation;
 
@@ -46,7 +52,7 @@ export default function validationPlugin (bookshelf, config = defaultConfig) {
                         validator,
                         fnName,
                         propValue,
-                        options
+                        args
                     );
 
                     if (!isValid) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,60 +1,64 @@
-module.exports = function (bookshelf, validator) {
-  'use strict';
+import validator from 'validator';
 
-  let Model = bookshelf.Model.extend({
-    validationErrors: function () {
-      let output = {};
-
-      function addError(propertyName, errorName) {
-        let propertyErrors = output[propertyName] || [];
-        propertyErrors.push(errorName);
-        output[propertyName] = propertyErrors;
-      }
-
-      // Validate each property with the given rule arguments
-      for (let propertyName in this.validations) {
-        let propertyValue = this.get(propertyName);
-        let validation = this.validations[propertyName];
-
-        // The 'isRequired' validation rule must be evaluated at first
-        if (propertyValue == null) {
-          if (validation.isRequired) {
-            addError(propertyName, 'isRequired');
-          }
-
-          // Step to the next validatable property
-          continue;
-        }
-
-        for (let functionName in validation) {
-          // Skip special validation functions
-          if (functionName === 'isRequired') {
-            continue;
-          }
-
-          // The argument can be a boolean for argumentless validation, or an
-          // array of options passed to the validator
-          let args = validation[functionName];
-          let isValid = new Function(
-            'validator',
-            'return ' + (
-              typeof args === 'boolean' ?
-                `validator.${functionName}('${propertyValue}') == ${args}` :
-                `validator.${functionName}('${propertyValue}', ${args.join()})`
-            )
-          )(validator || require('validator'));
-
-          // Handle validation errors if needed
-          if (!isValid) {
-            addError(propertyName, functionName);
-          }
-        }
-      }
-
-      // Return null if every property is valid
-      return Object.keys(output).length > 0 ? output : null;
-    }
-  });
-
-  bookshelf.Model = Model;
+const defaultConfig = {
+    validator,
 };
+
+function doValidation (validator, fnName, value, args) {
+    // The argument can be a boolean for argumentless validation, or an
+    // array of options passed to the validator
+    return typeof args === 'boolean' ?
+        validator[fnName](value) === args
+        : validator[fnName](value, args.join());
+}
+
+export default function validationPlugin (bookshelf, config = defaultConfig) {
+    var Plugin = {
+        validationErrors () {
+            const output = {};
+
+            function addError (propName, errorName) {
+                const propertyErrors = output[propName] || [];
+
+                propertyErrors.push(errorName);
+                output[propName] = propertyErrors;
+            }
+
+            // Validate each property with the given rule arguments
+            for (const propName in this.validations) {
+                if (!this.validations.hasOwnProperty(propName)) {
+                    return null;
+                }
+
+                const propValue = this.get(propName);
+                const validations = this.validations[propName];
+
+                for (const validation of validations) {
+                    const {
+                        method: fnName,
+                        options = true,
+                        error,
+                    } = validation;
+
+                    const isValid = doValidation(
+                        validator,
+                        fnName,
+                        propValue,
+                        options
+                    );
+
+                    if (!isValid) {
+                        const errorMsg = error ? error : method;
+
+                        addError(propName, errorMsg);
+                    }
+                }
+            }
+
+            // Return null if every property is valid
+            return Object.keys(output).length > 0 ? output : null;
+        },
+    };
+
+    bookshelf.Model = bookshelf.Model.extend(Plugin);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 import validator from 'validator';
+import ValidationError from './errors';
 
 const defaultConfig = {
     validator,
+    validateOnSave: false,
 };
 
 function doValidation (validator, fnName, value, args) {
@@ -59,6 +61,24 @@ export default function validationPlugin (bookshelf, config = defaultConfig) {
             return Object.keys(output).length > 0 ? output : null;
         },
     };
+
+    if (config.validateOnSave) {
+        Plugin.initialize = function initialize () {
+            if (typeof this.validateOnSave === 'function') {
+                this.on('saving', this.validateOnSave);
+            }
+        };
+
+        Plugin.validateOnSave = function validateOnSave () {
+            const errors = this.validationErrors();
+
+            if (errors == null) {
+                return null;
+            }
+
+            throw new ValidationError(errors);
+        };
+    }
 
     bookshelf.Model = bookshelf.Model.extend(Plugin);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,8 @@ const defaultConfig = {
 function doValidation (validator, fnName, value, options) {
     // The argument can be a boolean for argumentless validation, or an
     // array of options passed to the validator
-    return typeof args === 'boolean' ?
-        validator[fnName](value) === args
+    return typeof options === 'boolean' ?
+        validator[fnName](value) === options
         : validator[fnName](value, options);
 }
 


### PR DESCRIPTION
So this is almost a complete rewrite but let me know what you think.

Differences are:

validations now look like this (example from the app I'm working on)

```
    validations: {
        email: [
            {method: 'isRequired', error: 'ENOEMAIL'},
            {method: 'isEmail', error: 'EINVALIDEMAIL'},
        ],
    },
```

What was previously `args` (I called it "options") defaults to `true`, so it's not necessary to add it (for most simple boolean validators).

To add `isRequired` functionality is a single line:

```
validator.isRequired = val => val != null;
```

The `validator` object will default to `node-validator`, but you can pass in your own in the config object when you add the plugin to bookshelf.

You get back the full error object in the `.data` property on the `ValidationError`, it contains the attribute keys and array of your custom error strings.

The default is to not auto validate on save, but you can turn it on with the config object like this:

```
bookshelf.plugin(validationPlugin, {validator, validateOnSave: true});
```

I'm going to use it this way, not sure if you want to add all this to yours or not but it's basically perfect for me!
