### PR TITLE
Fix arguments slice

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,10 @@ function doValidation(validatorObj, fnName, value, args) {
     return validatorObj[fnName](value, args);
   }
 
+  // arguments is not an Array
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
   /* eslint prefer-rest-params: "off" */
-  return validatorObj[fnName].apply(validatorObj, arguments.slice(2));
+  return validatorObj[fnName].apply(validatorObj, Array.from(arguments).slice(2));
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,6 @@ function doValidation(validatorObj, fnName, value, args) {
     return validatorObj[fnName](value, args);
   }
 
-  // arguments is not an Array
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
   /* eslint prefer-rest-params: "off" */
   return validatorObj[fnName].apply(validatorObj, Array.from(arguments).slice(2));
 }


### PR DESCRIPTION
Fix for:

```
Unhandled rejection TypeError: arguments.slice is not a function
    at doValidation (/work/node/node-express-gamebase/node_modules/bookshelf-validate/lib/index.js:34:61)
```

when using following validations:

```
var Puppy = config.bookshelf.Model.extend({
  tableName: 'pups',
  validations: {
    name: { isRequired: true, isLength: [2, 32] },
    breed: { isRequired: true, isLength: [2, 32] },
    age: { isRequired: true },
    sex: { isRequired: true, isLength: [1, 1] }
  }
});
```

* Because arguments is not an Array
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
